### PR TITLE
bugfix: prevent scrolling on mobile menu when open

### DIFF
--- a/CSS/home.css
+++ b/CSS/home.css
@@ -10,6 +10,10 @@ body {
   width: 100%;
 }
 
+body.mobile-menu-open {
+  height: 100vh;
+}
+
 main {
   position: relative;
 }

--- a/js/script.js
+++ b/js/script.js
@@ -46,6 +46,10 @@ menuOptions.forEach(option => {
 hamburger.addEventListener('click', () => {
   toggleMenu()
   toggleOverlay()
+
+  // prevent scrolling on mobile-menu when open
+  const body = document.getElementsByTagName('body')[0]
+  body.classList.toggle('mobile-menu-open')
 })
 
 function toggleMenu() {


### PR DESCRIPTION
Prevents bug that happens when scrolling and mobile menu is open

**Before**
![before](https://github.com/Mara16/mara16.github.io/assets/4174313/f0252d71-3d9c-4b21-857a-498dbe8a10b5)

**After**
![after](https://github.com/Mara16/mara16.github.io/assets/4174313/8093f683-bd92-44ce-9388-9204a5058939)
