### PR TITLE
bugfix: prevent scrolling on mobile menu when open

### DIFF
--- a/CSS/home.css
+++ b/CSS/home.css
@@ -10,6 +10,10 @@ body {
   width: 100%;
 }
 
+body.mobile-menu-open {
+  height: 100vh;
+}
+
 main {
   position: relative;
 }

--- a/js/script.js
+++ b/js/script.js
@@ -46,6 +46,10 @@ menuOptions.forEach(option => {
 hamburger.addEventListener('click', () => {
   toggleMenu()
   toggleOverlay()
+
+  // prevent scrolling on mobile-menu when open
+  const body = document.getElementsByTagName('body')[0]
+  body.classList.toggle('mobile-menu-open')
 })
 
 function toggleMenu() {


### PR DESCRIPTION
Fixes bug occurring when scrolling on mobile menu when it's open

**Before**
![before](https://github.com/Mara16/mara16.github.io/assets/4174313/79f2b177-0930-46b7-bbe2-462122dc66eb)

**After**
![after](https://github.com/Mara16/mara16.github.io/assets/4174313/9c1ab01c-2441-494d-9bbb-f7491470e14a)
